### PR TITLE
adapt for go 1.11+

### DIFF
--- a/speedtest.rb
+++ b/speedtest.rb
@@ -12,7 +12,7 @@ class Speedtest < Formula
 
   def install
     ENV['GOPATH'] = buildpath
-    system 'go', 'get', 'gopkg.in/alecthomas/kingpin.v2'
+    system 'go', 'mod', 'init'
     system 'go', 'build', '-o', 'speedtest'
     bin.install 'speedtest'
   end


### PR DESCRIPTION
`$ go mod` is used to install dependent library from https://github.com/showwin/speedtest-go/pull/17