### PR TITLE
project name is required when initialize at outside GOPATH

### DIFF
--- a/speedtest.rb
+++ b/speedtest.rb
@@ -12,7 +12,7 @@ class Speedtest < Formula
 
   def install
     ENV['GOPATH'] = buildpath
-    system 'go', 'mod', 'init'
+    system 'go', 'mod', 'init', 'github.com/showwin/speedtest-go'
     system 'go', 'build', '-o', 'speedtest'
     bin.install 'speedtest'
   end


### PR DESCRIPTION
```
$ brew install speedtest

...

==> go mod init
Last 15 lines from /Users/showwin/Library/Logs/Homebrew/speedtest/01.go:
2021-04-04 14:48:12 +0900

go
mod
init

go: cannot determine module path for source directory /private/tmp/speedtest-20210404-7200-1gk0ny0 (outside GOPATH, module path must be specified)

Example usage:
	'go mod init example.com/m' to initialize a v0 or v1 module
	'go mod init example.com/m/v2' to initialize a v2 module

Run 'go help mod init' for more information.
```