### PR TITLE
GOPATH is not required when using go mod

### DIFF
--- a/speedtest.rb
+++ b/speedtest.rb
@@ -11,7 +11,6 @@ class Speedtest < Formula
   depends_on 'mercurial' => :build
 
   def install
-    ENV['GOPATH'] = buildpath
     system 'go', 'mod', 'init', 'github.com/showwin/speedtest-go'
     system 'go', 'build', '-o', 'speedtest'
     bin.install 'speedtest'


### PR DESCRIPTION
```
$ brew install speedtest

...

==> go mod init github.com/showwin/speedtest-go
Last 15 lines from /Users/showwin/Library/Logs/Homebrew/speedtest/01.go:
2021-04-04 14:55:39 +0900

go
mod
init
github.com/showwin/speedtest-go

$GOPATH/go.mod exists but should not

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/showwin/homebrew-speedtest/issues
  ```