### PR TITLE
go mod file already exists

### DIFF
--- a/speedtest.rb
+++ b/speedtest.rb
@@ -11,7 +11,6 @@ class Speedtest < Formula
   depends_on 'mercurial' => :build
 
   def install
-    system 'go', 'mod', 'init', 'github.com/showwin/speedtest-go'
     system 'go', 'build', '-o', 'speedtest'
     bin.install 'speedtest'
   end


### PR DESCRIPTION
```
$ brew install speedtest

...

==> go mod init github.com/showwin/speedtest-go
Last 15 lines from /Users/showwin/Library/Logs/Homebrew/speedtest/01.go:
2021-04-04 15:08:33 +0900

go
mod
init
github.com/showwin/speedtest-go

go: /private/tmp/speedtest-20210404-16269-1offhqw/go.mod already exists
```
